### PR TITLE
Add firebase-query.html to the my-app.html

### DIFF
--- a/src/my-app.html
+++ b/src/my-app.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../bower_components/iron-selector/iron-selector.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/polymerfire/firebase-app.html">
+<link rel="import" href="../bower_components/polymerfire/firebase-query.html">
 <link rel="import" href="my-icons.html">
 
 <dom-module id="my-app">


### PR DESCRIPTION
(I know that it is not a correct solution)

I'm not sure why, but adding the `firebase-query.html` to the `my-app.html`, now the websocket works.

Before:
<img width="663" alt="screen shot 2017-02-03 at 18 48 48" src="https://cloud.githubusercontent.com/assets/1007051/22601934/78cec11a-ea41-11e6-91d1-81ee30e29b53.png">

After:
<img width="649" alt="screen shot 2017-02-03 at 18 48 31" src="https://cloud.githubusercontent.com/assets/1007051/22601945/7e5a6c9c-ea41-11e6-9970-4401110fb229.png">

Updated:

I see the issue starts in the `^v0.10.1`. In the `v0.10.0` works well.
https://github.com/firebase/polymerfire/compare/v0.10.0...v0.10.1

Updated 2:

I think this PR introduces the issue: https://github.com/firebase/polymerfire/pull/131